### PR TITLE
fix: make staking-coin-denoms a positional argument

### DIFF
--- a/x/farming/client/cli/cli_test.go
+++ b/x/farming/client/cli/cli_test.go
@@ -56,7 +56,7 @@ func (s *IntegrationTestSuite) SetupTest() {
 	s.Require().NoError(err)
 }
 
-// TearDownTest cleans up the curret test network after each test in the suite.
+// TearDownTest cleans up the current test network after each test in the suite.
 func (s *IntegrationTestSuite) TearDownTest() {
 	s.T().Log("tearing down integration test suite")
 	s.network.Cleanup()
@@ -559,7 +559,7 @@ func (s *IntegrationTestSuite) TestNewHarvestCmd() {
 		{
 			"invalid transaction for no reward for staking coin denom stake",
 			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagStakingCoinDenoms, "stake"),
+				"stake",
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),
@@ -570,7 +570,7 @@ func (s *IntegrationTestSuite) TestNewHarvestCmd() {
 		{
 			"invalid staking coin denoms case #1",
 			[]string{
-				fmt.Sprintf("--%s=%s", cli.FlagStakingCoinDenoms, ""),
+				"!",
 				fmt.Sprintf("--%s=%s", flags.FlagFrom, val.Address.String()),
 				fmt.Sprintf("--%s=true", flags.FlagSkipConfirmation),
 				fmt.Sprintf("--%s=%s", flags.FlagBroadcastMode, flags.BroadcastBlock),

--- a/x/farming/client/cli/flags.go
+++ b/x/farming/client/cli/flags.go
@@ -7,12 +7,12 @@ import (
 )
 
 const (
-	FlagPlanType          = "plan-type"
-	FlagFarmingPoolAddr   = "farming-pool-addr"
-	FlagTerminationAddr   = "termination-addr"
-	FlagFarmerAddr        = "farmer-addr"
-	FlagStakingCoinDenom  = "staking-coin-denom"
-	FlagStakingCoinDenoms = "staking-coin-denoms"
+	FlagPlanType         = "plan-type"
+	FlagFarmingPoolAddr  = "farming-pool-addr"
+	FlagTerminationAddr  = "termination-addr"
+	FlagFarmerAddr       = "farmer-addr"
+	FlagStakingCoinDenom = "staking-coin-denom"
+	FlagAll              = "all"
 )
 
 func flagSetPlans() *flag.FlagSet {
@@ -45,7 +45,7 @@ func flagSetRewards() *flag.FlagSet {
 func flagSetHarvest() *flag.FlagSet {
 	fs := flag.NewFlagSet("", flag.ContinueOnError)
 
-	fs.StringSlice(FlagStakingCoinDenoms, []string{""}, "The staking coin denoms to harvest farming rewards")
+	fs.Bool(FlagAll, false, "Harvest for all staking coin denoms")
 
 	return fs
 }

--- a/x/farming/client/cli/flags.go
+++ b/x/farming/client/cli/flags.go
@@ -10,7 +10,6 @@ const (
 	FlagPlanType         = "plan-type"
 	FlagFarmingPoolAddr  = "farming-pool-addr"
 	FlagTerminationAddr  = "termination-addr"
-	FlagFarmerAddr       = "farmer-addr"
 	FlagStakingCoinDenom = "staking-coin-denom"
 	FlagAll              = "all"
 )


### PR DESCRIPTION
## Description

by specifing `--all` flag, staking-coin-denoms can be omitted

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
