### PR TITLE
fix: terminate plan when deleting public plan proposal

### DIFF
--- a/x/farming/keeper/plan.go
+++ b/x/farming/keeper/plan.go
@@ -260,7 +260,6 @@ func (k Keeper) TerminatePlan(ctx sdk.Context, plan types.PlanI) error {
 			sdk.NewAttribute(types.AttributeKeyPlanId, strconv.FormatUint(plan.GetId(), 10)),
 			sdk.NewAttribute(types.AttributeKeyFarmingPoolAddress, plan.GetFarmingPoolAddress().String()),
 			sdk.NewAttribute(types.AttributeKeyTerminationAddress, plan.GetTerminationAddress().String()),
-			// TODO: add refunded coins?
 		),
 	})
 

--- a/x/farming/keeper/plan.go
+++ b/x/farming/keeper/plan.go
@@ -240,10 +240,12 @@ func (k Keeper) CreateRatioPlan(ctx sdk.Context, msg *types.MsgCreateRatioPlan, 
 // TerminatePlan sends all remaining coins in the plan's farming pool to
 // the termination address and mark the plan as terminated.
 func (k Keeper) TerminatePlan(ctx sdk.Context, plan types.PlanI) error {
-	balances := k.bankKeeper.GetAllBalances(ctx, plan.GetFarmingPoolAddress())
-	if balances.IsAllPositive() {
-		if err := k.bankKeeper.SendCoins(ctx, plan.GetFarmingPoolAddress(), plan.GetTerminationAddress(), balances); err != nil {
-			return err
+	if plan.GetFarmingPoolAddress().String() != plan.GetTerminationAddress().String() {
+		balances := k.bankKeeper.GetAllBalances(ctx, plan.GetFarmingPoolAddress())
+		if balances.IsAllPositive() {
+			if err := k.bankKeeper.SendCoins(ctx, plan.GetFarmingPoolAddress(), plan.GetTerminationAddress(), balances); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/x/farming/keeper/proposal_handler.go
+++ b/x/farming/keeper/proposal_handler.go
@@ -225,10 +225,8 @@ func (k Keeper) DeletePublicPlanProposal(ctx sdk.Context, proposals []*types.Del
 			return sdkerrors.Wrapf(sdkerrors.ErrNotFound, "plan %d is not found", p.GetPlanId())
 		}
 
-		if plan.GetFarmingPoolAddress().String() != plan.GetTerminationAddress().String() {
-			if err := k.TerminatePlan(ctx, plan); err != nil {
-				panic(err)
-			}
+		if err := k.TerminatePlan(ctx, plan); err != nil {
+			panic(err)
 		}
 
 		k.RemovePlan(ctx, plan)

--- a/x/farming/keeper/proposal_handler.go
+++ b/x/farming/keeper/proposal_handler.go
@@ -225,6 +225,12 @@ func (k Keeper) DeletePublicPlanProposal(ctx sdk.Context, proposals []*types.Del
 			return sdkerrors.Wrapf(sdkerrors.ErrNotFound, "plan %d is not found", p.GetPlanId())
 		}
 
+		if plan.GetFarmingPoolAddress().String() != plan.GetTerminationAddress().String() {
+			if err := k.TerminatePlan(ctx, plan); err != nil {
+				panic(err)
+			}
+		}
+
 		k.RemovePlan(ctx, plan)
 
 		logger := k.Logger(ctx)

--- a/x/farming/keeper/proposal_handler_test.go
+++ b/x/farming/keeper/proposal_handler_test.go
@@ -539,7 +539,15 @@ func (suite *KeeperTestSuite) TestDeletePublicPlan() {
 			_, found := suite.keeper.GetPlan(suite.ctx, plans[0].GetId())
 			suite.Require().Equal(false, found)
 
+			// check balances
 			suite.Require().Equal(tc.expectedBalances, suite.app.BankKeeper.GetAllBalances(suite.ctx, tc.farmingPoolAddr))
+
+			for _, e := range suite.ctx.EventManager().ABCIEvents() {
+				switch e.Type {
+				case types.EventTypePlanTerminated:
+					suite.Require().NotEmpty(e.Attributes)
+				}
+			}
 		})
 	}
 }

--- a/x/farming/keeper/proposal_handler_test.go
+++ b/x/farming/keeper/proposal_handler_test.go
@@ -503,7 +503,7 @@ func (suite *KeeperTestSuite) TestDeletePublicPlan() {
 	)
 	suite.Require().NoError(err)
 
-	_, found := suite.keeper.GetPlan(suite.ctx, uint64(1))
+	plan, found := suite.keeper.GetPlan(suite.ctx, uint64(1))
 	suite.Require().Equal(true, found)
 
 	// check farming pool address initial balances
@@ -515,7 +515,7 @@ func (suite *KeeperTestSuite) TestDeletePublicPlan() {
 		suite.ctx,
 		suite.keeper,
 		types.NewPublicPlanProposal("testTitle", "testDescription", nil, nil, []*types.DeleteRequestProposal{
-			types.NewDeleteRequestProposal(1),
+			types.NewDeleteRequestProposal(plan.GetId()),
 		}),
 	)
 	suite.Require().NoError(err)

--- a/x/farming/spec/08_proposal.md
+++ b/x/farming/spec/08_proposal.md
@@ -2,7 +2,13 @@
 
 # Proposal
 
-The farming module contains the following public plan governance proposal that receives one of the following requests. A request `AddRequestProposal` that creates a public farming plan, a request `UpdateRequestProposal` that updates the plan, and a request `DeleteRequestProposal` that deletes the plan. For most cases, it expects that a single request is used, but note that `PublicPlanProposal` accepts more than a single request to cover broader use cases. Also,
+The farming module contains the following public plan governance proposal that receives one of the following requests. 
+
+- `AddRequestProposal` is the request proposal that requests the module to create a public farming plan. You can either input epoch amount `EpochAmount` or epoch ratio `EpochRatio`. Depending on which value of the parameter you input, it creates the following plan type `FixedAmountPlan` or `RatioPlan`.
+
+- `UpdateRequestProposal` is the request proposal that requests the module to update the plan. You can also update the plan type. 
+
+- `DeleteRequestProposal` is the request proposal that requests the module to delete the plan. It sends all remaining coins in the plan's farming pool `FarmingPoolAddress` to the termination address `TerminationAddress` and mark the plan as terminated.
 
 ## PublicPlanProposal
 
@@ -26,7 +32,7 @@ type PublicPlanProposal struct {
 
 ## AddRequestProposal
 
-Note that when requesting `AddRequestProposal` depending on which field is passed, either `EpochAmount` or `EpochRatio`, it creates a `FixedAmountPlan` or `RatioPlan`.
+You can either input epoch amount `EpochAmount` or epoch ratio `EpochRatio`. Depending on which value of the parameter you input, it creates the following plan type `FixedAmountPlan` or `RatioPlan`.
 
 ```go
 // AddRequestProposal details a proposal for creating a public plan.
@@ -81,6 +87,8 @@ type UpdateRequestProposal struct {
 ```
 
 ## DeleteRequestProposal
+
+The request requests the module to delete the plan and it sends all remaining coins in the plan's farming pool `FarmingPoolAddress` to the termination address `TerminationAddress` and mark the plan as terminated.
 
 ```go
 // DeleteRequestProposal details a proposal for deleting an existing public plan.


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

closes: #161 

## Tasks

- [x] Add `TerminationPlan` logic in `DeletePublicPlanProposal` 
     * Handle an edge case where `FarmingPoolAddress` and `TerminationAddress` are equal
- [x] Add test code to cover the case
- [x] Update related docs

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Appropriate labels applied
- [ ] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
