### PR TITLE
fix: emit `rewards_withdrawn` event

### DIFF
--- a/x/farming/keeper/reward.go
+++ b/x/farming/keeper/reward.go
@@ -2,6 +2,7 @@ package keeper
 
 import (
 	"strconv"
+	"strings"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	gogotypes "github.com/gogo/protobuf/types"
@@ -234,6 +235,14 @@ func (k Keeper) Harvest(ctx sdk.Context, farmerAcc sdk.AccAddress, stakingCoinDe
 		}
 		totalRewards = totalRewards.Add(rewards...)
 	}
+
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeHarvest,
+			sdk.NewAttribute(types.AttributeKeyFarmer, farmerAcc.String()),
+			sdk.NewAttribute(types.AttributeKeyStakingCoinDenoms, strings.Join(stakingCoinDenoms, ",")),
+		),
+	})
 
 	return nil
 }

--- a/x/farming/keeper/reward.go
+++ b/x/farming/keeper/reward.go
@@ -184,6 +184,15 @@ func (k Keeper) WithdrawRewards(ctx sdk.Context, farmerAcc sdk.AccAddress, staki
 	staking.StartingEpoch = currentEpoch
 	k.SetStaking(ctx, stakingCoinDenom, farmerAcc, staking)
 
+	ctx.EventManager().EmitEvents(sdk.Events{
+		sdk.NewEvent(
+			types.EventTypeRewardsWithdrawn,
+			sdk.NewAttribute(types.AttributeKeyFarmer, farmerAcc.String()),
+			sdk.NewAttribute(types.AttributeKeyStakingCoinDenom, stakingCoinDenom),
+			sdk.NewAttribute(types.AttributeKeyRewardCoins, truncatedRewards.String()),
+		),
+	})
+
 	return truncatedRewards, nil
 }
 
@@ -225,14 +234,6 @@ func (k Keeper) Harvest(ctx sdk.Context, farmerAcc sdk.AccAddress, stakingCoinDe
 		}
 		totalRewards = totalRewards.Add(rewards...)
 	}
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeHarvest,
-			sdk.NewAttribute(types.AttributeKeyFarmer, farmerAcc.String()),
-			sdk.NewAttribute(types.AttributeKeyRewardCoins, totalRewards.String()),
-		),
-	})
 
 	return nil
 }

--- a/x/farming/spec/06_events.md
+++ b/x/farming/spec/06_events.md
@@ -6,13 +6,16 @@ The farming module emits the following events:
 
 ## EndBlocker
 
-| Type              | Attribute Key        | Attribute Value          |
-| ----------------- | -------------------- | ------------------------ |
-| plan_terminated   | plan_id              | {planID}                 |
-| plan_terminated   | farming_pool_address | {farmingPoolAddress}     |
-| plan_terminated   | termination_address  | {terminationAddress}     |
-| rewards_allocated | plan_id              | {planID}                 |
-| rewards_allocated | amount               | {totalAllocatedAmount}   |
+| Type              | Attribute Key        | Attribute Value        |
+| ----------------- | -------------------- | ---------------------- |
+| plan_terminated   | plan_id              | {planID}               |
+| plan_terminated   | farming_pool_address | {farmingPoolAddress}   |
+| plan_terminated   | termination_address  | {terminationAddress}   |
+| rewards_allocated | plan_id              | {planID}               |
+| rewards_allocated | amount               | {totalAllocatedAmount} |
+| rewards_withdrawn | farmer               | {farmer}               |
+| rewards_withdrawn | staking_coin_denom   | {stakingCoinDenom}     |
+| rewards_withdrawn | rewards_coins        | {rewardCoins}          |
 
 ## Handlers
 
@@ -56,23 +59,27 @@ The farming module emits the following events:
 
 ### MsgUnstake
 
-| Type    | Attribute Key   | Attribute Value  |
-| ------- | --------------- | ---------------- |
-| unstake | farmer          | {farmer}         |
-| unstake | unstaking_coins | {unstakingCoins} | 
-| message | module          | farming          |
-| message | action          | unstake          |
-| message | sender          | {senderAddress}  |
+| Type              | Attribute Key      | Attribute Value    |
+| ----------------- | ------------------ | ------------------ |
+| unstake           | farmer             | {farmer}           |
+| unstake           | unstaking_coins    | {unstakingCoins}   |
+| rewards_withdrawn | farmer             | {farmer}           |
+| rewards_withdrawn | staking_coin_denom | {stakingCoinDenom} |
+| rewards_withdrawn | rewards_coins      | {rewardCoins}      |
+| message           | module             | farming            |
+| message           | action             | unstake            |
+| message           | sender             | {senderAddress}    |
 
 ### MsgHarvest
 
-| Type    | Attribute Key | Attribute Value |
-| ------- | ------------- | --------------- |
-| harvest | farmer        | {farmer}        |
-| harvest | reward_coins  | {rewardCoins}   |
-| message | module        | farming         |
-| message | action        | harvest         |
-| message | sender        | {senderAddress} |
+| Type    | Attribute Key       | Attribute Value     |
+| ------- | ------------------- | ------------------- |
+| harvest | farmer              | {farmer}            |
+| harvest | staking_coin_denoms | {stakingCoinDenoms} |
+| message | module              | farming             |
+| message | action              | harvest             |
+| message | sender              | {senderAddress}     |
+
 ### MsgAdvanceEpoch
 
 This message is for testing purpose. It is only available when you build `farmingd` binary by `make install-testing` command.

--- a/x/farming/types/events.go
+++ b/x/farming/types/events.go
@@ -6,6 +6,7 @@ const (
 	EventTypeCreateRatioPlan       = "create_ratio_plan"
 	EventTypeStake                 = "stake"
 	EventTypeUnstake               = "unstake"
+	EventTypeHarvest               = "harvest"
 	EventTypeRewardsWithdrawn      = "rewards_withdrawn"
 	EventTypePlanTerminated        = "plan_terminated"
 	EventTypeRewardsAllocated      = "rewards_allocated"
@@ -24,4 +25,5 @@ const (
 	AttributeKeyFarmer             = "farmer"
 	AttributeKeyAmount             = "amount"
 	AttributeKeyStakingCoinDenom   = "staking_coin_denom"
+	AttributeKeyStakingCoinDenoms  = "staking_coin_denoms"
 )

--- a/x/farming/types/events.go
+++ b/x/farming/types/events.go
@@ -6,7 +6,7 @@ const (
 	EventTypeCreateRatioPlan       = "create_ratio_plan"
 	EventTypeStake                 = "stake"
 	EventTypeUnstake               = "unstake"
-	EventTypeHarvest               = "harvest"
+	EventTypeRewardsWithdrawn      = "rewards_withdrawn"
 	EventTypePlanTerminated        = "plan_terminated"
 	EventTypeRewardsAllocated      = "rewards_allocated"
 
@@ -23,4 +23,5 @@ const (
 	AttributeKeyEpochRatio         = "epoch_ratio"
 	AttributeKeyFarmer             = "farmer"
 	AttributeKeyAmount             = "amount"
+	AttributeKeyStakingCoinDenom   = "staking_coin_denom"
 )


### PR DESCRIPTION
## Description

`Keeper.WithdrawRewards` is called in several places:
- `Keeper.Harvest`
- `Keeper.ProcessQueuedCoins`
- `Keeper.Unstake`

so instead of emitting `harvest` event in `Keeper.Harvest`,
emit `rewards_withdrawn` event in these places.

note that this new event will be emitted
multiple times for a farmer(for each staking coin denom
the farmer has).

closes: #164 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
