### PR TITLE
feat: bump budget to v0.1.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
-	github.com/tendermint/budget v0.1.0
+	github.com/tendermint/budget v0.1.1
 	github.com/tendermint/tendermint v0.34.13
 	github.com/tendermint/tm-db v0.6.4
 	google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c

--- a/go.sum
+++ b/go.sum
@@ -996,8 +996,8 @@ github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c h1:g+WoO5jjkqGAzH
 github.com/tecbot/gorocksdb v0.0.0-20191217155057-f0fad39f321c/go.mod h1:ahpPrc7HpcfEWDQRZEmnXMzHY03mLDYMCxeDzy46i+8=
 github.com/tendermint/btcd v0.1.1 h1:0VcxPfflS2zZ3RiOAHkBiFUcPvbtRj5O7zHmcJWHV7s=
 github.com/tendermint/btcd v0.1.1/go.mod h1:DC6/m53jtQzr/NFmMNEu0rxf18/ktVoVtMrnDD5pN+U=
-github.com/tendermint/budget v0.1.0 h1:V1rJUxQOn2tIrBmxVEmhkuB/48j5hQ1TC6xjeoTpKms=
-github.com/tendermint/budget v0.1.0/go.mod h1:49m91ZgK5qDsIXs5EHNeBrXXrb3XXaDQuFWvmiKxyyY=
+github.com/tendermint/budget v0.1.1 h1:a0cQpeZNI+XGdGsUTIh1QffbgEOYW/qIn+KnMKit8LM=
+github.com/tendermint/budget v0.1.1/go.mod h1:m1aq7qIV9FeNw3FM89QAd9ztb0ffiAeO1Gxh5XZu7XQ=
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15 h1:hqAk8riJvK4RMWx1aInLzndwxKalgi5rTqgfXxOxbEI=
 github.com/tendermint/crypto v0.0.0-20191022145703-50d29ede1e15/go.mod h1:z4YtwM70uOnk8h0pjJYlj3zdYwi9l03By6iAIF5j/Pk=
 github.com/tendermint/go-amino v0.16.0 h1:GyhmgQKvqF82e2oZeuMSp9JTN0N09emoSZlb2lyGa2E=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

When we release https://github.com/tendermint/farming/releases/tag/v0.1.1, missed bump budget module to https://github.com/tendermint/budget/releases/tag/v0.1.1
so we plan to release farming v0.1.2 containing budget v0.1.1 with other improvements early next week

