### PR TITLE
fix: emit rewards_withdrawn only when positive amount is withdrawn

### DIFF
--- a/x/farming/keeper/reward.go
+++ b/x/farming/keeper/reward.go
@@ -218,6 +218,15 @@ func (k Keeper) WithdrawRewards(ctx sdk.Context, farmerAcc sdk.AccAddress, staki
 			if err := k.bankKeeper.SendCoins(ctx, k.GetRewardsReservePoolAcc(ctx), farmerAcc, truncatedRewards); err != nil {
 				return nil, err
 			}
+
+			ctx.EventManager().EmitEvents(sdk.Events{
+				sdk.NewEvent(
+					types.EventTypeRewardsWithdrawn,
+					sdk.NewAttribute(types.AttributeKeyFarmer, farmerAcc.String()),
+					sdk.NewAttribute(types.AttributeKeyStakingCoinDenom, stakingCoinDenom),
+					sdk.NewAttribute(types.AttributeKeyRewardCoins, truncatedRewards.String()),
+				),
+			})
 		}
 
 		k.DecreaseOutstandingRewards(ctx, stakingCoinDenom, rewards)
@@ -225,15 +234,6 @@ func (k Keeper) WithdrawRewards(ctx sdk.Context, farmerAcc sdk.AccAddress, staki
 
 	staking.StartingEpoch = currentEpoch
 	k.SetStaking(ctx, stakingCoinDenom, farmerAcc, staking)
-
-	ctx.EventManager().EmitEvents(sdk.Events{
-		sdk.NewEvent(
-			types.EventTypeRewardsWithdrawn,
-			sdk.NewAttribute(types.AttributeKeyFarmer, farmerAcc.String()),
-			sdk.NewAttribute(types.AttributeKeyStakingCoinDenom, stakingCoinDenom),
-			sdk.NewAttribute(types.AttributeKeyRewardCoins, truncatedRewards.String()),
-		),
-	})
 
 	return truncatedRewards, nil
 }


### PR DESCRIPTION
## Description

Currently, `rewards_withdraw` event is emitted whenever `WithdrawRewards` is called.
Fix this to only emit event when positive rewards amount is withdrawn.

https://github.com/tendermint/farming/blob/69db071ce30b99617b8ba9bb6efac76e74cd100b/x/farming/keeper/reward.go#L216-L236

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
