### PR TITLE
test: implement test for PositiveTotalStakingsAmountInvariant

### DIFF
--- a/x/farming/keeper/invariants_test.go
+++ b/x/farming/keeper/invariants_test.go
@@ -276,6 +276,22 @@ func (suite *KeeperTestSuite) TestNonNegativeHistoricalRewardsInvariant() {
 }
 
 func (suite *KeeperTestSuite) TestPositiveTotalStakingsAmountInvariant() {
+	k, ctx := suite.keeper, suite.ctx
+
+	// This is normal.
+	k.SetTotalStakings(ctx, denom1, types.TotalStakings{Amount: sdk.NewInt(1000000)})
+	_, broken := farmingkeeper.PositiveTotalStakingsAmountInvariant(k)(ctx)
+	suite.Require().False(broken)
+
+	// Zero-amount total stakings.
+	k.SetTotalStakings(ctx, denom1, types.TotalStakings{Amount: sdk.ZeroInt()})
+	_, broken = farmingkeeper.PositiveTotalStakingsAmountInvariant(k)(ctx)
+	suite.Require().True(broken)
+
+	// Negative-amount total stakings.
+	k.SetTotalStakings(ctx, denom1, types.TotalStakings{Amount: sdk.NewInt(-1)})
+	_, broken = farmingkeeper.PositiveTotalStakingsAmountInvariant(k)(ctx)
+	suite.Require().True(broken)
 }
 
 func (suite *KeeperTestSuite) TestPlanTerminationStatusInvariant() {


### PR DESCRIPTION
## Description

I just found that I forgot to implement `TestPositiveTotalStakingsAmountInvariant`.
`TestPlanTerminationStatusInvariant` is also left as empty, but that invariant check is considered to be removed entirely.
See #217 for details.

## References

#217

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
