### PR TITLE
fix: defer the deletion of past historical rewards to the end-block

### DIFF
--- a/x/farming/abci.go
+++ b/x/farming/abci.go
@@ -15,6 +15,8 @@ func EndBlocker(ctx sdk.Context, k keeper.Keeper) {
 
 	logger := k.Logger(ctx)
 
+	k.PruneTotalStakings(ctx)
+
 	for _, plan := range k.GetPlans(ctx) {
 		if !plan.GetTerminated() && ctx.BlockTime().After(plan.GetEndTime()) {
 			if err := k.TerminatePlan(ctx, plan); err != nil {

--- a/x/farming/keeper/reward_test.go
+++ b/x/farming/keeper/reward_test.go
@@ -6,6 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	simapp "github.com/tendermint/farming/app"
+	"github.com/tendermint/farming/x/farming"
 	"github.com/tendermint/farming/x/farming/types"
 
 	_ "github.com/stretchr/testify/suite"
@@ -496,6 +497,7 @@ func (suite *KeeperTestSuite) TestInitializeAndPruneStakingCoinInfo() {
 	// Now unstake the rest of the coins. This should delete info
 	// about the staking coin.
 	suite.Unstake(suite.addrs[0], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1)))
+	farming.EndBlocker(suite.ctx, suite.keeper)
 	suite.Require().Equal(uint64(0), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
 	_, found = suite.keeper.GetHistoricalRewards(suite.ctx, denom1, 1)
 	suite.Require().False(found)

--- a/x/farming/keeper/staking.go
+++ b/x/farming/keeper/staking.go
@@ -180,13 +180,13 @@ func (k Keeper) DeleteTotalStakings(ctx sdk.Context, stakingCoinDenom string) {
 // IncreaseTotalStakings increases total stakings for given staking coin denom
 // by given amount.
 func (k Keeper) IncreaseTotalStakings(ctx sdk.Context, stakingCoinDenom string, amount sdk.Int) {
-	totalStaking, found := k.GetTotalStakings(ctx, stakingCoinDenom)
+	totalStakings, found := k.GetTotalStakings(ctx, stakingCoinDenom)
 	if !found {
-		totalStaking.Amount = sdk.ZeroInt()
+		totalStakings.Amount = sdk.ZeroInt()
 	}
-	totalStaking.Amount = totalStaking.Amount.Add(amount)
-	k.SetTotalStakings(ctx, stakingCoinDenom, totalStaking)
-	if totalStaking.Amount.Equal(amount) {
+	totalStakings.Amount = totalStakings.Amount.Add(amount)
+	k.SetTotalStakings(ctx, stakingCoinDenom, totalStakings)
+	if totalStakings.Amount.Equal(amount) {
 		k.afterStakingCoinAdded(ctx, stakingCoinDenom)
 	}
 }
@@ -194,19 +194,15 @@ func (k Keeper) IncreaseTotalStakings(ctx sdk.Context, stakingCoinDenom string, 
 // DecreaseTotalStakings decreases total stakings for given staking coin denom
 // by given amount.
 func (k Keeper) DecreaseTotalStakings(ctx sdk.Context, stakingCoinDenom string, amount sdk.Int) {
-	totalStaking, found := k.GetTotalStakings(ctx, stakingCoinDenom)
+	totalStakings, found := k.GetTotalStakings(ctx, stakingCoinDenom)
 	if !found {
 		panic("total stakings not found")
 	}
-	if totalStaking.Amount.Equal(amount) {
-		k.DeleteTotalStakings(ctx, stakingCoinDenom)
-		if err := k.afterStakingCoinRemoved(ctx, stakingCoinDenom); err != nil {
-			panic(err)
-		}
-	} else {
-		totalStaking.Amount = totalStaking.Amount.Sub(amount)
-		k.SetTotalStakings(ctx, stakingCoinDenom, totalStaking)
+	if totalStakings.Amount.LT(amount) {
+		panic("cannot set negative total stakings")
 	}
+	totalStakings.Amount = totalStakings.Amount.Sub(amount)
+	k.SetTotalStakings(ctx, stakingCoinDenom, totalStakings)
 }
 
 // IterateTotalStakings iterates through all total stakings
@@ -413,6 +409,20 @@ func (k Keeper) ProcessQueuedCoins(ctx sdk.Context) {
 			StartingEpoch: k.GetCurrentEpoch(ctx, stakingCoinDenom),
 		})
 
+		return false
+	})
+}
+
+// PruneTotalStakings deletes total stakings with amount of zero and calls
+// cleanup logic for each staking coin denom.
+func (k Keeper) PruneTotalStakings(ctx sdk.Context) {
+	k.IterateTotalStakings(ctx, func(stakingCoinDenom string, totalStakings types.TotalStakings) (stop bool) {
+		if totalStakings.Amount.IsZero() {
+			k.DeleteTotalStakings(ctx, stakingCoinDenom)
+			if err := k.afterStakingCoinRemoved(ctx, stakingCoinDenom); err != nil {
+				panic(err)
+			}
+		}
 		return false
 	})
 }

--- a/x/farming/keeper/staking_test.go
+++ b/x/farming/keeper/staking_test.go
@@ -4,9 +4,12 @@ import (
 	"math/rand"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	_ "github.com/stretchr/testify/suite"
+
 	simapp "github.com/tendermint/farming/app"
+	"github.com/tendermint/farming/x/farming"
 	"github.com/tendermint/farming/x/farming/types"
+
+	_ "github.com/stretchr/testify/suite"
 )
 
 func (suite *KeeperTestSuite) TestStake() {
@@ -257,6 +260,7 @@ func (suite *KeeperTestSuite) TestTotalStakings() {
 	suite.Require().True(intEq(sdk.NewInt(200000), totalStakings.Amount))
 
 	suite.Unstake(suite.addrs[0], sdk.NewCoins(sdk.NewInt64Coin(denom1, 200000)))
+	farming.EndBlocker(suite.ctx, suite.keeper)
 	_, found = suite.keeper.GetTotalStakings(suite.ctx, denom1)
 	suite.Require().False(found)
 }


### PR DESCRIPTION
## Description

This PR implements delayed deletion of past historical rewards.

Closes: #240

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
