### PR TITLE
fix: register types on legacy amino codec

### DIFF
--- a/x/farming/module.go
+++ b/x/farming/module.go
@@ -42,7 +42,7 @@ func (AppModuleBasic) Name() string {
 
 // RegisterLegacyAminoCodec registers the farming module's types for the given codec.
 func (AppModuleBasic) RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-	// types.RegisterLegacyAminoCodec(cdc)
+	types.RegisterLegacyAminoCodec(cdc)
 }
 
 // DefaultGenesis returns default genesis state as raw bytes for the farming

--- a/x/farming/simulation/operations_test.go
+++ b/x/farming/simulation/operations_test.go
@@ -25,7 +25,7 @@ func TestWeightedOperations(t *testing.T) {
 
 	ctx.WithChainID("test-chain")
 
-	cdc := app.AppCodec()
+	cdc := types.ModuleCdc
 	appParams := make(simtypes.AppParams)
 
 	weightedOps := simulation.WeightedOperations(appParams, cdc, app.AccountKeeper, app.BankKeeper, app.FarmingKeeper)
@@ -84,7 +84,7 @@ func TestSimulateMsgCreateFixedAmountPlan(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg types.MsgCreateFixedAmountPlan
-	err = app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+	err = types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 	require.NoError(t, err)
 
 	require.True(t, operationMsg.OK)
@@ -122,7 +122,7 @@ func TestSimulateMsgCreateRatioPlan(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg types.MsgCreateRatioPlan
-	err = app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+	err = types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 	require.NoError(t, err)
 
 	require.True(t, operationMsg.OK)
@@ -158,7 +158,7 @@ func TestSimulateMsgStake(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg types.MsgStake
-	err = app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+	err = types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 	require.NoError(t, err)
 
 	require.True(t, operationMsg.OK)
@@ -199,7 +199,7 @@ func TestSimulateMsgUnstake(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg types.MsgUnstake
-	err = app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+	err = types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 	require.NoError(t, err)
 
 	require.True(t, operationMsg.OK)
@@ -271,7 +271,7 @@ func TestSimulateMsgHarvest(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg types.MsgHarvest
-	err = app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+	err = types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 	require.NoError(t, err)
 
 	require.True(t, operationMsg.OK)
@@ -337,7 +337,7 @@ func TestSimulateMsgRemovePlan(t *testing.T) {
 	require.NoError(t, err)
 
 	var msg types.MsgRemovePlan
-	err = app.AppCodec().UnmarshalJSON(operationMsg.Msg, &msg)
+	err = types.ModuleCdc.UnmarshalJSON(operationMsg.Msg, &msg)
 	require.NoError(t, err)
 
 	require.True(t, operationMsg.OK)

--- a/x/farming/simulation/proposals_test.go
+++ b/x/farming/simulation/proposals_test.go
@@ -4,8 +4,9 @@ import (
 	"math/rand"
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/tendermint/farming/app/params"
 	"github.com/tendermint/farming/x/farming/simulation"

--- a/x/farming/types/codec.go
+++ b/x/farming/types/codec.go
@@ -1,21 +1,28 @@
 package types
 
 import (
+	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
+	cryptocodec "github.com/cosmos/cosmos-sdk/crypto/codec"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/msgservice"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 )
 
-// // RegisterLegacyAminoCodec registers the necessary x/farming interfaces and concrete types
-// // on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
-// func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
-// 	cdc.RegisterConcrete(&MsgCreateFixedAmountPlan{}, "farming/MsgCreateFixedAmountPlan", nil)
-// 	cdc.RegisterConcrete(&MsgCreateRatioPlan{}, "farming/MsgCreateRatioPlan", nil)
-// 	cdc.RegisterConcrete(&MsgStake{}, "farming/MsgStake", nil)
-// 	cdc.RegisterConcrete(&MsgUnstake{}, "farming/MsgUnstake", nil)
-// 	cdc.RegisterConcrete(&MsgHarvest{}, "farming/MsgHarvest", nil)
-// }
+// RegisterLegacyAminoCodec registers the necessary x/farming interfaces and concrete types
+// on the provided LegacyAmino codec. These types are used for Amino JSON serialization.
+func RegisterLegacyAminoCodec(cdc *codec.LegacyAmino) {
+	cdc.RegisterInterface((*PlanI)(nil), nil)
+	cdc.RegisterConcrete(&MsgCreateFixedAmountPlan{}, "farming/MsgCreateFixedAmountPlan", nil)
+	cdc.RegisterConcrete(&MsgCreateRatioPlan{}, "farming/MsgCreateRatioPlan", nil)
+	cdc.RegisterConcrete(&MsgStake{}, "farming/MsgStake", nil)
+	cdc.RegisterConcrete(&MsgUnstake{}, "farming/MsgUnstake", nil)
+	cdc.RegisterConcrete(&MsgHarvest{}, "farming/MsgHarvest", nil)
+	cdc.RegisterConcrete(&MsgRemovePlan{}, "farming/MsgRemovePlan", nil)
+	cdc.RegisterConcrete(&FixedAmountPlan{}, "farming/FixedAmountPlan", nil)
+	cdc.RegisterConcrete(&RatioPlan{}, "farming/RatioPlan", nil)
+	cdc.RegisterConcrete(&PublicPlanProposal{}, "farming/PublicPlanProposal", nil)
+}
 
 // RegisterInterfaces registers the x/farming interfaces types with the interface registry
 func RegisterInterfaces(registry types.InterfaceRegistry) {
@@ -44,20 +51,20 @@ func RegisterInterfaces(registry types.InterfaceRegistry) {
 	msgservice.RegisterMsgServiceDesc(registry, &_Msg_serviceDesc)
 }
 
-// var (
-// 	amino = codec.NewLegacyAmino()
+var (
+	amino = codec.NewLegacyAmino()
 
-// 	// ModuleCdc references the global x/farming module codec. Note, the codec
-// 	// should ONLY be used in certain instances of tests and for JSON encoding as Amino
-// 	// is still used for that purpose.
-// 	//
-// 	// The actual codec used for serialization should be provided to x/farming and
-// 	// defined at the application level.
-// 	ModuleCdc = codec.NewAminoCodec(amino)
-// )
+	// ModuleCdc references the global x/farming module codec. Note, the codec
+	// should ONLY be used in certain instances of tests and for JSON encoding as Amino
+	// is still used for that purpose.
+	//
+	// The actual codec used for serialization should be provided to x/farming and
+	// defined at the application level.
+	ModuleCdc = codec.NewAminoCodec(amino)
+)
 
-// func init() {
-// 	RegisterLegacyAminoCodec(amino)
-// 	cryptocodec.RegisterCrypto(amino)
-// 	amino.Seal()
-// }
+func init() {
+	RegisterLegacyAminoCodec(amino)
+	cryptocodec.RegisterCrypto(amino)
+	amino.Seal()
+}

--- a/x/farming/types/msgs.go
+++ b/x/farming/types/msgs.go
@@ -3,7 +3,6 @@ package types
 import (
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )
@@ -72,7 +71,7 @@ func (msg MsgCreateFixedAmountPlan) ValidateBasic() error {
 }
 
 func (msg MsgCreateFixedAmountPlan) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgCreateFixedAmountPlan) GetSigners() []sdk.AccAddress {
@@ -134,7 +133,7 @@ func (msg MsgCreateRatioPlan) ValidateBasic() error {
 }
 
 func (msg MsgCreateRatioPlan) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgCreateRatioPlan) GetSigners() []sdk.AccAddress {
@@ -182,7 +181,7 @@ func (msg MsgStake) ValidateBasic() error {
 }
 
 func (msg MsgStake) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgStake) GetSigners() []sdk.AccAddress {
@@ -230,7 +229,7 @@ func (msg MsgUnstake) ValidateBasic() error {
 }
 
 func (msg MsgUnstake) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgUnstake) GetSigners() []sdk.AccAddress {
@@ -280,7 +279,7 @@ func (msg MsgHarvest) ValidateBasic() error {
 }
 
 func (msg MsgHarvest) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgHarvest) GetSigners() []sdk.AccAddress {
@@ -325,7 +324,7 @@ func (msg MsgRemovePlan) ValidateBasic() error {
 }
 
 func (msg MsgRemovePlan) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgRemovePlan) GetSigners() []sdk.AccAddress {
@@ -363,7 +362,7 @@ func (msg MsgAdvanceEpoch) ValidateBasic() error {
 }
 
 func (msg MsgAdvanceEpoch) GetSignBytes() []byte {
-	return sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(&msg))
+	return sdk.MustSortJSON(ModuleCdc.MustMarshalJSON(&msg))
 }
 
 func (msg MsgAdvanceEpoch) GetSigners() []sdk.AccAddress {

--- a/x/farming/types/msgs_test.go
+++ b/x/farming/types/msgs_test.go
@@ -4,11 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cosmos/cosmos-sdk/codec/legacy"
 	"github.com/stretchr/testify/require"
-	"github.com/tendermint/tendermint/crypto"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/tendermint/tendermint/crypto"
 
 	"github.com/tendermint/farming/x/farming/types"
 )
@@ -65,7 +64,7 @@ func TestMsgCreateFixedAmountPlan(t *testing.T) {
 		require.IsType(t, &types.MsgCreateFixedAmountPlan{}, tc.msg)
 		require.Equal(t, types.TypeMsgCreateFixedAmountPlan, tc.msg.Type())
 		require.Equal(t, types.RouterKey, tc.msg.Route())
-		require.Equal(t, sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
+		require.Equal(t, sdk.MustSortJSON(types.ModuleCdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
 
 		err := tc.msg.ValidateBasic()
 		if tc.expectedErr == "" {
@@ -131,7 +130,7 @@ func TestMsgCreateRatioPlan(t *testing.T) {
 		require.IsType(t, &types.MsgCreateRatioPlan{}, tc.msg)
 		require.Equal(t, types.TypeMsgCreateRatioPlan, tc.msg.Type())
 		require.Equal(t, types.RouterKey, tc.msg.Route())
-		require.Equal(t, sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
+		require.Equal(t, sdk.MustSortJSON(types.ModuleCdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
 
 		err := tc.msg.ValidateBasic()
 		if tc.expectedErr == "" {
@@ -171,7 +170,7 @@ func TestMsgStake(t *testing.T) {
 		require.IsType(t, &types.MsgStake{}, tc.msg)
 		require.Equal(t, types.TypeMsgStake, tc.msg.Type())
 		require.Equal(t, types.RouterKey, tc.msg.Route())
-		require.Equal(t, sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
+		require.Equal(t, sdk.MustSortJSON(types.ModuleCdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
 
 		err := tc.msg.ValidateBasic()
 		if tc.expectedErr == "" {
@@ -211,7 +210,7 @@ func TestMsgUnstake(t *testing.T) {
 		require.IsType(t, &types.MsgUnstake{}, tc.msg)
 		require.Equal(t, types.TypeMsgUnstake, tc.msg.Type())
 		require.Equal(t, types.RouterKey, tc.msg.Route())
-		require.Equal(t, sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
+		require.Equal(t, sdk.MustSortJSON(types.ModuleCdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
 
 		err := tc.msg.ValidateBasic()
 		if tc.expectedErr == "" {
@@ -251,7 +250,7 @@ func TestMsgHarvest(t *testing.T) {
 		require.IsType(t, &types.MsgHarvest{}, tc.msg)
 		require.Equal(t, types.TypeMsgHarvest, tc.msg.Type())
 		require.Equal(t, types.RouterKey, tc.msg.Route())
-		require.Equal(t, sdk.MustSortJSON(legacy.Cdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
+		require.Equal(t, sdk.MustSortJSON(types.ModuleCdc.MustMarshalJSON(tc.msg)), tc.msg.GetSignBytes())
 
 		err := tc.msg.ValidateBasic()
 		if tc.expectedErr == "" {


### PR DESCRIPTION
## Description

This will make x/farming compatible with ledger devices

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
