### PR TITLE
fix: preserve `CurrentEpoch` when all farmers has unstaked

### DIFF
--- a/x/farming/keeper/reward_test.go
+++ b/x/farming/keeper/reward_test.go
@@ -498,7 +498,6 @@ func (suite *KeeperTestSuite) TestInitializeAndPruneStakingCoinInfo() {
 	// about the staking coin.
 	suite.Unstake(suite.addrs[0], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1)))
 	farming.EndBlocker(suite.ctx, suite.keeper)
-	suite.Require().Equal(uint64(0), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
 	_, found = suite.keeper.GetHistoricalRewards(suite.ctx, denom1, 1)
 	suite.Require().False(found)
 	_, found = suite.keeper.GetOutstandingRewards(suite.ctx, denom1)

--- a/x/farming/keeper/staking.go
+++ b/x/farming/keeper/staking.go
@@ -266,7 +266,12 @@ func (k Keeper) ReleaseStakingCoins(ctx sdk.Context, farmerAcc sdk.AccAddress, s
 // during ProcessQueuedCoins.
 func (k Keeper) afterStakingCoinAdded(ctx sdk.Context, stakingCoinDenom string) {
 	k.SetHistoricalRewards(ctx, stakingCoinDenom, 0, types.HistoricalRewards{CumulativeUnitRewards: sdk.DecCoins{}})
-	k.SetCurrentEpoch(ctx, stakingCoinDenom, 1)
+	currentEpoch := k.GetCurrentEpoch(ctx, stakingCoinDenom)
+	if currentEpoch == 0 {
+		k.SetCurrentEpoch(ctx, stakingCoinDenom, 1)
+	} else {
+		k.SetCurrentEpoch(ctx, stakingCoinDenom, currentEpoch+1)
+	}
 	k.SetOutstandingRewards(ctx, stakingCoinDenom, types.OutstandingRewards{Rewards: sdk.DecCoins{}})
 }
 
@@ -290,7 +295,6 @@ func (k Keeper) afterStakingCoinRemoved(ctx sdk.Context, stakingCoinDenom string
 
 	k.DeleteOutstandingRewards(ctx, stakingCoinDenom)
 	k.DeleteAllHistoricalRewards(ctx, stakingCoinDenom)
-	k.DeleteCurrentEpoch(ctx, stakingCoinDenom)
 	return nil
 }
 

--- a/x/farming/keeper/staking_test.go
+++ b/x/farming/keeper/staking_test.go
@@ -459,3 +459,50 @@ func (suite *KeeperTestSuite) TestReserveAndReleaseStakingCoins() {
 		})
 	}
 }
+
+func (suite *KeeperTestSuite) TestPreserveCurrentEpoch() {
+	suite.CreateFixedAmountPlan(suite.addrs[0], map[string]string{denom1: "1"}, map[string]int64{denom2: 1000000})
+
+	suite.Require().Equal(uint64(0), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.Stake(suite.addrs[1], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000)))
+	suite.AdvanceEpoch()
+	suite.Require().Equal(uint64(1), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.AdvanceEpoch()
+	suite.Require().Equal(uint64(2), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.Require().True(coinsEq(sdk.NewCoins(sdk.NewInt64Coin(denom2, 1000000)), suite.AllRewards(suite.addrs[1])))
+
+	balancesBefore := suite.app.BankKeeper.GetAllBalances(suite.ctx, suite.addrs[1])
+	suite.Unstake(suite.addrs[1], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000)))
+	farming.EndBlocker(suite.ctx, suite.keeper)
+	balancesAfter := suite.app.BankKeeper.GetAllBalances(suite.ctx, suite.addrs[1])
+	suite.Require().Equal(uint64(2), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.Require().True(coinsEq(
+		sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000), sdk.NewInt64Coin(denom2, 1000000)),
+		balancesAfter.Sub(balancesBefore)))
+
+	// Few days later...
+	suite.AdvanceEpoch()
+	suite.AdvanceEpoch()
+	suite.AdvanceEpoch()
+	suite.AdvanceEpoch()
+
+	suite.Stake(suite.addrs[2], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000)))
+	suite.Require().Equal(uint64(2), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.AdvanceEpoch()
+	suite.Require().Equal(uint64(3), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.AdvanceEpoch()
+	suite.Require().Equal(uint64(4), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.Require().True(coinsEq(sdk.NewCoins(sdk.NewInt64Coin(denom2, 1000000)), suite.AllRewards(suite.addrs[2])))
+
+	balancesBefore = suite.app.BankKeeper.GetAllBalances(suite.ctx, suite.addrs[2])
+	suite.Unstake(suite.addrs[2], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000)))
+	farming.EndBlocker(suite.ctx, suite.keeper)
+	balancesAfter = suite.app.BankKeeper.GetAllBalances(suite.ctx, suite.addrs[2])
+	suite.Require().Equal(uint64(4), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+	suite.Require().True(coinsEq(
+		sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000), sdk.NewInt64Coin(denom2, 1000000)),
+		balancesAfter.Sub(balancesBefore)))
+
+	suite.AdvanceEpoch()
+	suite.Require().Equal(uint64(4), suite.keeper.GetCurrentEpoch(suite.ctx, denom1))
+}

--- a/x/farming/spec/02_state.md
+++ b/x/farming/spec/02_state.md
@@ -124,7 +124,7 @@ The parameters of the plan state are:
 
 - LastEpochTime: `[]byte("lastEpochTime") -> ProtocolBuffer(Timestamp)`
 
-- CurrentEpochDays: `[]byte("currentEpochDays") -> uint32` 
+- CurrentEpochDays: `[]byte("currentEpochDays") -> ProtocolBuffer(uint32)`
 
 ## Staking
 
@@ -169,8 +169,8 @@ type HistoricalRewards struct {
 ```
 
 - HistoricalRewards: `0x31 | StakingCoinDenomLen (1 byte) | StakingCoinDenom | BigEndian(Epoch) -> ProtocolBuffer(HistoricalRewards)`
-- CurrentEpoch: `0x32 | StakingCoinDenom -> BigEndian(CurrentEpoch)`
-
+- CurrentEpoch: `0x32 | StakingCoinDenom -> ProtocolBuffer(uint64)`
+  - CurrentEpoch remains unchanged after all farmers has unstaked their coins.
 ## Outstanding Rewards
 
 The `OutstandingRewards` struct holds outstanding (un-withdrawn) rewards for a staking denom.

--- a/x/farming/spec/02_state.md
+++ b/x/farming/spec/02_state.md
@@ -168,7 +168,7 @@ type HistoricalRewards struct {
 }
 ```
 
-- HistoricalRewards: `0x31 | StakingCoinDenomLen (1 byte) | StakingCoinDenom | BigEndian(Epoch) -> ProtocolBuffer(HistoricalRewards)`
+- HistoricalRewards: `0x31 | StakingCoinDenomLen (1 byte) | StakingCoinDenom | Epoch -> ProtocolBuffer(HistoricalRewards)`
 - CurrentEpoch: `0x32 | StakingCoinDenom -> ProtocolBuffer(uint64)`
   - CurrentEpoch remains unchanged after all farmers has unstaked their coins.
 ## Outstanding Rewards


### PR DESCRIPTION
## Description

`CurrentEpoch` should be continuous even if all farmers has unstaked their coins.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
