### PR TITLE
fix: skip zero total stakings when allocating rewards

### DIFF
--- a/x/farming/keeper/reward.go
+++ b/x/farming/keeper/reward.go
@@ -420,7 +420,7 @@ func (k Keeper) AllocateRewards(ctx sdk.Context) error {
 			totalStakingsPtr, ok := totalStakingsCache[weight.Denom]
 			if !ok {
 				totalStakings, found := k.GetTotalStakings(ctx, weight.Denom)
-				if !found {
+				if !found || totalStakings.Amount.IsZero() {
 					totalStakingsCache[weight.Denom] = nil
 					continue
 				}

--- a/x/farming/keeper/reward.go
+++ b/x/farming/keeper/reward.go
@@ -420,7 +420,7 @@ func (k Keeper) AllocateRewards(ctx sdk.Context) error {
 			totalStakingsPtr, ok := totalStakingsCache[weight.Denom]
 			if !ok {
 				totalStakings, found := k.GetTotalStakings(ctx, weight.Denom)
-				if !found || totalStakings.Amount.IsZero() {
+				if !found || !totalStakings.Amount.IsPositive() {
 					totalStakingsCache[weight.Denom] = nil
 					continue
 				}

--- a/x/farming/keeper/reward_test.go
+++ b/x/farming/keeper/reward_test.go
@@ -503,3 +503,21 @@ func (suite *KeeperTestSuite) TestInitializeAndPruneStakingCoinInfo() {
 	_, found = suite.keeper.GetOutstandingRewards(suite.ctx, denom1)
 	suite.Require().False(found)
 }
+
+func (suite *KeeperTestSuite) TestAllocateRewardsZeroTotalStakings() {
+	suite.CreateFixedAmountPlan(suite.addrs[4], map[string]string{denom1: "1"}, map[string]int64{denom3: 1000000})
+
+	suite.Stake(suite.addrs[0], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000)))
+	suite.AdvanceEpoch()
+	suite.AdvanceEpoch()
+
+	suite.Unstake(suite.addrs[0], sdk.NewCoins(sdk.NewInt64Coin(denom1, 1000000)))
+	suite.AdvanceEpoch() // This should not cause a panic.
+	totalStakings, found := suite.keeper.GetTotalStakings(suite.ctx, denom1)
+	suite.Require().True(found)
+	suite.Require().True(totalStakings.Amount.IsZero())
+	farming.EndBlocker(suite.ctx, suite.keeper)
+
+	_, found = suite.keeper.GetTotalStakings(suite.ctx, denom1)
+	suite.Require().False(found)
+}


### PR DESCRIPTION
## Description

This prevents panics when `AdvanceEpoch` is called together with `Unstake` within the same block.

## References

- https://github.com/cosmosquad-labs/squad/issues/260

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
