### PR TITLE
refactor: disable ratio plans by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,8 @@ endif
 ldflags += $(LDFLAGS)
 ldflags := $(strip $(ldflags))
 
-testing_ldflags = -X github.com/tendermint/farming/x/farming/keeper.enableAdvanceEpoch=true
+testing_ldflags = -X github.com/tendermint/farming/x/farming/keeper.enableAdvanceEpoch=true \
+                  -X github.com/tendermint/farming/x/farming/keeper.enableRatioPlan=true
 
 BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags)'
 TESTING_BUILD_FLAGS := -tags "$(build_tags)" -ldflags '$(ldflags) $(testing_ldflags)'

--- a/docs/How-To/cli/README.md
+++ b/docs/How-To/cli/README.md
@@ -147,6 +147,8 @@ Result:
 
 ### MsgCreateRatioPlan
 
+***This message is disabled by default, you have to build the binary with `make install-testing` to activate this message.***
+
 Anyone can create this private plan type message. A ratio plan plans to distribute amount of coins by ratio that is defined in `EpochRatio`. Internally, `PrivatePlanFarmingPoolAddress` is generated and assigned to the plan. The creator must query the plan and send amount of coins to the farming pool address so that the plan distributes as intended. For a ratio plan, whichever coins that the farming pool address has in balances are used every epoch. To prevent spamming attacks, a `PlanCreationFee` fee must be paid on plan creation.
 
 Create the `private-fixed-plan.json` file. This private ratio farming plan intends to provide ratio of all coins that farming pool address has per epoch (measured in day). In this example, epoch ratio is 10 percent and 10 percent of all the coins that the creator of this plan has in balances are used as incentives for the denoms that are defined in the staking coin weights.

--- a/docs/Tutorials/demo/budget_with_farming.md
+++ b/docs/Tutorials/demo/budget_with_farming.md
@@ -41,6 +41,8 @@ One use case is to use the module to provide incentives for liquidity pool inves
 
 ### Step 1. Build from source
 
+***Since the creation of ratio plans through msg server or gov proposal is disabled by default, you have to build the binary with `make install-testing` to activate it.***
+
 ```bash
 # Clone the demo project and build `farmingd` for testing
 git clone -b v1.0.0 https://github.com/tendermint/farming.git

--- a/docs/Tutorials/demo/plans.md
+++ b/docs/Tutorials/demo/plans.md
@@ -4,9 +4,9 @@ There are two different types of farming plans in the farming module. Whereas a 
 
 In this documentation, some sample data in JSON are provided. They will be used to test out farming plan functionality.
 
-## Table of Contetns
+## Table of Contents
 
-- [Bootstrap Local Network](#Boostrap)
+- [Bootstrap Local Network](#Bootstrap)
 - [Public Farming Plan](#Public-Farming-Plan)
   * [AddPublicFarmingFixedAmountPlan](#AddPublicFarmingFixedAmountPlan)
   * [AddPublicFarmingRatioPlan](#AddPublicFarmingRatioPlan)
@@ -19,11 +19,13 @@ In this documentation, some sample data in JSON are provided. They will be used 
 
 # Bootstrap
 
+***Since the creation of ratio plans through msg server or gov proposal is disabled by default, you have to build the binary with `make install-testing` to activate it.***
+
 ```bash
 # Clone the project 
 git clone https://github.com/tendermint/farming.git
 cd farming
-make install
+make install-testing
 
 # Configure variables
 export BINARY=farmingd

--- a/x/farming/client/cli/tx.go
+++ b/x/farming/client/cli/tx.go
@@ -35,12 +35,14 @@ func GetTxCmd() *cobra.Command {
 
 	farmingTxCmd.AddCommand(
 		NewCreateFixedAmountPlanCmd(),
-		NewCreateRatioPlanCmd(),
 		NewStakeCmd(),
 		NewUnstakeCmd(),
 		NewHarvestCmd(),
 		NewRemovePlanCmd(),
 	)
+	if keeper.EnableRatioPlan {
+		farmingTxCmd.AddCommand(NewCreateRatioPlanCmd())
+	}
 	if keeper.EnableAdvanceEpoch {
 		farmingTxCmd.AddCommand(NewAdvanceEpochCmd())
 	}

--- a/x/farming/handler.go
+++ b/x/farming/handler.go
@@ -1,8 +1,6 @@
 package farming
 
 import (
-	"fmt"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
@@ -43,9 +41,6 @@ func NewHandler(k keeper.Keeper) sdk.Handler {
 			return sdk.WrapServiceResult(ctx, res, err)
 
 		case *types.MsgAdvanceEpoch:
-			if !keeper.EnableAdvanceEpoch {
-				return nil, fmt.Errorf("AdvanceEpoch is disabled")
-			}
 			res, err := msgServer.AdvanceEpoch(sdk.WrapSDKContext(ctx), msg)
 			return sdk.WrapServiceResult(ctx, res, err)
 

--- a/x/farming/keeper/keeper.go
+++ b/x/farming/keeper/keeper.go
@@ -15,15 +15,25 @@ import (
 
 var (
 	enableAdvanceEpoch = "false" // Set this to "true" using build flags to enable AdvanceEpoch msg handling.
+	enableRatioPlan    = "false" // Set this to "true" using build flags to enable creation of RatioPlans.
 
 	// EnableAdvanceEpoch indicates whether msgServer accepts MsgAdvanceEpoch or not.
 	// Never set this to true in production mode. Doing that will expose serious attack vector.
 	EnableAdvanceEpoch = false
+	// EnableRatioPlan indicates whether msgServer and proposal handler accept
+	// creation of RatioPlans.
+	// Default is false, which means that RatioPlans can't be created through a
+	// MsgCreateRatioPlan msg and a PublicPlanProposal.
+	EnableRatioPlan = false
 )
 
 func init() {
 	var err error
 	EnableAdvanceEpoch, err = strconv.ParseBool(enableAdvanceEpoch)
+	if err != nil {
+		panic(err)
+	}
+	EnableRatioPlan, err = strconv.ParseBool(enableRatioPlan)
 	if err != nil {
 		panic(err)
 	}

--- a/x/farming/keeper/keeper_test.go
+++ b/x/farming/keeper/keeper_test.go
@@ -57,6 +57,8 @@ func (suite *KeeperTestSuite) SetupTest() {
 	app := simapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
+	keeper.EnableRatioPlan = true
+
 	suite.app = app
 	suite.ctx = ctx
 	suite.keeper = suite.app.FarmingKeeper

--- a/x/farming/keeper/keeper_test.go
+++ b/x/farming/keeper/keeper_test.go
@@ -42,6 +42,7 @@ type KeeperTestSuite struct {
 	ctx                 sdk.Context
 	keeper              keeper.Keeper
 	querier             keeper.Querier
+	msgServer           types.MsgServer
 	govHandler          govtypes.Handler
 	addrs               []sdk.AccAddress
 	sampleFixedAmtPlans []types.PlanI
@@ -63,6 +64,7 @@ func (suite *KeeperTestSuite) SetupTest() {
 	suite.ctx = ctx
 	suite.keeper = suite.app.FarmingKeeper
 	suite.querier = keeper.Querier{Keeper: suite.keeper}
+	suite.msgServer = keeper.NewMsgServerImpl(suite.keeper)
 	suite.govHandler = farming.NewPublicPlanProposalHandler(suite.keeper)
 	suite.addrs = simapp.AddTestAddrs(suite.app, suite.ctx, 6, sdk.ZeroInt())
 	for _, addr := range suite.addrs {

--- a/x/farming/keeper/msg_server.go
+++ b/x/farming/keeper/msg_server.go
@@ -44,6 +44,11 @@ func (k msgServer) CreateFixedAmountPlan(goCtx context.Context, msg *types.MsgCr
 // CreateRatioPlan defines a method for creating ratio farming plan.
 func (k msgServer) CreateRatioPlan(goCtx context.Context, msg *types.MsgCreateRatioPlan) (*types.MsgCreateRatioPlanResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
+
+	if !EnableRatioPlan {
+		return nil, types.ErrRatioPlanDisabled
+	}
+
 	poolAcc, err := k.DerivePrivatePlanFarmingPoolAcc(ctx, msg.Name)
 	if err != nil {
 		return nil, err

--- a/x/farming/keeper/proposal_handler.go
+++ b/x/farming/keeper/proposal_handler.go
@@ -66,6 +66,10 @@ func (k Keeper) AddPublicPlanProposal(ctx sdk.Context, proposals []types.AddPlan
 			logger := k.Logger(ctx)
 			logger.Info("created public fixed amount plan", "fixed_amount_plan", plan)
 		} else {
+			if !EnableRatioPlan {
+				return types.ErrRatioPlanDisabled
+			}
+
 			msg := types.NewMsgCreateRatioPlan(
 				p.GetName(),
 				farmingPoolAcc,
@@ -152,6 +156,10 @@ func (k Keeper) ModifyPublicPlanProposal(ctx sdk.Context, proposals []types.Modi
 			logger.Info("updated public fixed amount plan", "fixed_amount_plan", plan)
 
 		} else if p.IsForRatioPlan() {
+			if !EnableRatioPlan {
+				return types.ErrRatioPlanDisabled
+			}
+
 			// change the plan to ratio plan
 			plan = types.NewRatioPlan(plan.GetBasePlan(), p.EpochRatio)
 

--- a/x/farming/module_test.go
+++ b/x/farming/module_test.go
@@ -48,6 +48,8 @@ func (suite *ModuleTestSuite) SetupTest() {
 	app := simapp.Setup(false)
 	ctx := app.BaseApp.NewContext(false, tmproto.Header{})
 
+	keeper.EnableRatioPlan = true
+
 	suite.app = app
 	suite.ctx = ctx
 	suite.keeper = suite.app.FarmingKeeper

--- a/x/farming/simulation/operations.go
+++ b/x/farming/simulation/operations.go
@@ -40,6 +40,10 @@ var (
 	}
 )
 
+func init() {
+	keeper.EnableRatioPlan = true
+}
+
 // WeightedOperations returns all the operations from the module with their respective weights.
 func WeightedOperations(
 	appParams simtypes.AppParams, cdc codec.JSONCodec, ak types.AccountKeeper,

--- a/x/farming/simulation/operations_test.go
+++ b/x/farming/simulation/operations_test.go
@@ -15,6 +15,7 @@ import (
 
 	farmingapp "github.com/tendermint/farming/app"
 	"github.com/tendermint/farming/app/params"
+	"github.com/tendermint/farming/x/farming/keeper"
 	"github.com/tendermint/farming/x/farming/simulation"
 	"github.com/tendermint/farming/x/farming/types"
 )
@@ -100,6 +101,7 @@ func TestSimulateMsgCreateFixedAmountPlan(t *testing.T) {
 // Abnormal scenarios, where the message are created by an errors are not tested here.
 func TestSimulateMsgCreateRatioPlan(t *testing.T) {
 	app, ctx := createTestApp(false)
+	keeper.EnableRatioPlan = true
 
 	// setup a single account
 	s := rand.NewSource(1)

--- a/x/farming/spec/04_messages.md
+++ b/x/farming/spec/04_messages.md
@@ -30,6 +30,8 @@ type MsgCreateFixedAmountPlan struct {
 
 ## MsgCreateRatioPlan
 
+***This message is disabled by default, you have to build the binary with `make install-testing` to activate this message.***
+
 Anyone can create this private plan type message. 
 
 - A ratio plan plans to distribute amount of coins by ratio defined in `EpochRatio`.
@@ -108,13 +110,9 @@ type MsgRemovePlan struct {
 
 ## MsgAdvanceEpoch
 
-For testing purposes only, this custom message is used to advance epoch by 1. 
+***This message is disabled by default, you have to build the binary with `make install-testing` to activate this message.***
 
-To enable this message, you must build the `farmingd` binary:
-
-```sh
-make install-testing
-```
+For testing purposes only, this custom message is used to advance epoch by 1.
 
 When you send the `MsgAdvanceEpoch` message to the network, epoch increases by 1.
 

--- a/x/farming/spec/08_proposal.md
+++ b/x/farming/spec/08_proposal.md
@@ -11,7 +11,7 @@ The `farming` module contains the following public plan governance proposal that
 - `DeletePlanRequest` is the request proposal that requests the module to delete the plan. It sends all remaining coins in the plan's farming pool `FarmingPoolAddress` to the termination address `TerminationAddress` and mark the plan as terminated.
 
 Note that adding or modifying `RatioPlan`s is disabled by default.
-The binary should be built using `make-install` command to enable that.
+The binary should be built using `make install-testing` command to enable that.
 
 ## PublicPlanProposal
 

--- a/x/farming/spec/08_proposal.md
+++ b/x/farming/spec/08_proposal.md
@@ -10,6 +10,9 @@ The `farming` module contains the following public plan governance proposal that
 
 - `DeletePlanRequest` is the request proposal that requests the module to delete the plan. It sends all remaining coins in the plan's farming pool `FarmingPoolAddress` to the termination address `TerminationAddress` and mark the plan as terminated.
 
+Note that adding or modifying `RatioPlan`s is disabled by default.
+The binary should be built using `make-install` command to enable that.
+
 ## PublicPlanProposal
 
 ```go

--- a/x/farming/types/errors.go
+++ b/x/farming/types/errors.go
@@ -19,4 +19,5 @@ var (
 	ErrNumPrivatePlansLimit            = sdkerrors.Register(ModuleName, 12, "cannot create private plans more than the limit")
 	ErrNumMaxDenomsLimit               = sdkerrors.Register(ModuleName, 13, "number of denoms cannot exceed the limit")
 	ErrInvalidEpochAmount              = sdkerrors.Register(ModuleName, 14, "invalid epoch amount")
+	ErrRatioPlanDisabled               = sdkerrors.Register(ModuleName, 15, "creation of ratio plans is disabled")
 )


### PR DESCRIPTION
## Description

Disable creation of `RatioPlan`s by default.
It can be enabled by passing `enableRatioPlan=true` build flag, just like `MsgAdvanceEpoch`.

## References

- https://github.com/tendermint/farming/pull/258#issuecomment-1076134828

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Appropriate labels applied
- [x] Targeted PR against correct branch
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [x] Wrote unit and integration
- [x] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [x] Added relevant `godoc` [comments](https://go.dev/blog/godoc).
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
